### PR TITLE
Support for pixels with a value of zero

### DIFF
--- a/colour_demosaicing/bayer/demosaicing/malvar2004.py
+++ b/colour_demosaicing/bayer/demosaicing/malvar2004.py
@@ -120,27 +120,31 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     G = CFA * G_m
     B = CFA * B_m
 
-    GRBG = scipy.signal.convolve2d(CFA, GR_GB,'same')
+    GRBG = scipy.signal.convolve2d(CFA, GR_GB, 'same')
     GRBG = np.clip(GRBG,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
     G = np.where(np.logical_or(R_m == 1, B_m == 1), GRBG, G)
 
-    RBg_RBBR = scipy.signal.convolve2d(CFA, Rg_RB_Bg_BR,'same')
+    RBg_RBBR = scipy.signal.convolve2d(CFA, Rg_RB_Bg_BR, 'same')
     RBg_RBBR = np.clip(RBg_RBBR,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
 
-    RBg_BRRB = scipy.signal.convolve2d(CFA, Rg_BR_Bg_RB,'same')
+    RBg_BRRB = scipy.signal.convolve2d(CFA, Rg_BR_Bg_RB, 'same')
     RBg_BRRB = np.clip(RBg_BRRB,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
 
-    RBgr_BBRR = scipy.signal.convolve2d(CFA, Rb_BB_Br_RR,'same')
-    RBgr_BBRR = np.clip(RBgr_BBRR,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
+    RBgr_BBRR = scipy.signal.convolve2d(CFA, Rb_BB_Br_RR, 'same')
+    RBgr_BBRR = np.clip(RBgr_BBRR, 0, np.iinfo(CFA.dtype).max).astype(CFA.dtype)
 
     # Red rows.
-    R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) * np.ones(R.shape,dtype='bool')
+    R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) \
+        * np.ones(R.shape, dtype='bool')
     # Red columns.
-    R_c = np.any(R_m == 1, axis=0)[np.newaxis] * np.ones(R.shape,dtype='bool')
+    R_c = np.any(R_m == 1, axis=0)[np.newaxis] \
+        * np.ones(R.shape, dtype='bool')
     # Blue rows.
-    B_r = np.transpose(np.any(B_m == 1, axis=1)[np.newaxis]) * np.ones(B.shape,dtype='bool')
+    B_r = np.transpose(np.any(B_m == 1, axis=1)[np.newaxis]) \
+        * np.ones(B.shape, dtype='bool')
     # Blue columns
-    B_c = np.any(B_m == 1, axis=0)[np.newaxis] * np.ones(B.shape,dtype='bool')
+    B_c = np.any(B_m == 1, axis=0)[np.newaxis] \
+        * np.ones(B.shape, dtype='bool')
 
     R = np.where(np.logical_and(R_r == 1, B_c == 1), RBg_RBBR, R)
     R = np.where(np.logical_and(B_r == 1, R_c == 1), RBg_BRRB, R)

--- a/colour_demosaicing/bayer/demosaicing/malvar2004.py
+++ b/colour_demosaicing/bayer/demosaicing/malvar2004.py
@@ -121,17 +121,23 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     B = CFA * B_m
 
     GRBG = scipy.signal.convolve2d(CFA, GR_GB, 'same')
-    GRBG = np.clip(GRBG,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
+    #GRBG = np.clip(GRBG,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
+    GRBG[GRBG < 0] = 0
+    GRBG = GRBG.astype(CFA.dtype)
+
     G = np.where(np.logical_or(R_m == 1, B_m == 1), GRBG, G)
 
     RBg_RBBR = scipy.signal.convolve2d(CFA, Rg_RB_Bg_BR, 'same')
-    RBg_RBBR = np.clip(RBg_RBBR,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
+    RBg_RBBR[RBg_RBBR < 0] = 0
+    RBg_RBBR = RBg_RBBR.astype(CFA.dtype)
 
     RBg_BRRB = scipy.signal.convolve2d(CFA, Rg_BR_Bg_RB, 'same')
-    RBg_BRRB = np.clip(RBg_BRRB,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
+    RBg_BRRB[RBg_BRRB < 0] = 0
+    RBg_BRRB = RBg_BRRB.astype(CFA.dtype)
 
     RBgr_BBRR = scipy.signal.convolve2d(CFA, Rb_BB_Br_RR, 'same')
-    RBgr_BBRR = np.clip(RBgr_BBRR, 0, np.iinfo(CFA.dtype).max).astype(CFA.dtype)
+    RBgr_BBRR[RBgr_BBRR < 0] = 0
+    RBgr_BBRR = RBgr_BBRR.astype(CFA.dtype)
 
     # Red rows.
     R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) \

--- a/colour_demosaicing/bayer/demosaicing/malvar2004.py
+++ b/colour_demosaicing/bayer/demosaicing/malvar2004.py
@@ -120,24 +120,20 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     G = CFA * G_m
     B = CFA * B_m
 
-    GRBG = scipy.signal.convolve2d(CFA, GR_GB, 'same')
-    #GRBG = np.clip(GRBG,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
-    GRBG[GRBG < 0] = 0
-    GRBG = GRBG.astype(CFA.dtype)
+    dtypemax = 1.0 if isinstance(CFA, float) else np.iinfo(CFA.dtype).max
 
+    GRBG = scipy.signal.convolve2d(CFA, GR_GB, 'same')
+    GRBG = np.clip(GRBG, 0, dtypemax).astype(CFA.dtype)
     G = np.where(np.logical_or(R_m == 1, B_m == 1), GRBG, G)
 
     RBg_RBBR = scipy.signal.convolve2d(CFA, Rg_RB_Bg_BR, 'same')
-    RBg_RBBR[RBg_RBBR < 0] = 0
-    RBg_RBBR = RBg_RBBR.astype(CFA.dtype)
+    RBg_RBBR = np.clip(RBg_RBBR, 0, dtypemax).astype(CFA.dtype)  
 
     RBg_BRRB = scipy.signal.convolve2d(CFA, Rg_BR_Bg_RB, 'same')
-    RBg_BRRB[RBg_BRRB < 0] = 0
-    RBg_BRRB = RBg_BRRB.astype(CFA.dtype)
+    RBg_BRRB = np.clip(RBg_BRRB, 0, dtypemax).astype(CFA.dtype)
 
     RBgr_BBRR = scipy.signal.convolve2d(CFA, Rb_BB_Br_RR, 'same')
-    RBgr_BBRR[RBgr_BBRR < 0] = 0
-    RBgr_BBRR = RBgr_BBRR.astype(CFA.dtype)
+    RBgr_BBRR = np.clip(RBgr_BBRR, 0, dtypemax).astype(CFA.dtype)
 
     # Red rows.
     R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) \

--- a/colour_demosaicing/bayer/demosaicing/malvar2004.py
+++ b/colour_demosaicing/bayer/demosaicing/malvar2004.py
@@ -20,7 +20,7 @@ References
 from __future__ import division, unicode_literals
 
 import numpy as np
-from scipy.ndimage.filters import convolve
+import scipy.signal
 from colour import tstack
 
 from colour_demosaicing.bayer import masks_CFA_Bayer
@@ -120,20 +120,27 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     G = CFA * G_m
     B = CFA * B_m
 
-    G = np.where(np.logical_or(R_m == 1, B_m == 1), convolve(CFA, GR_GB), G)
+    GRBG = scipy.signal.convolve2d(CFA, GR_GB,'same')
+    GRBG = np.clip(GRBG,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
+    G = np.where(np.logical_or(R_m == 1, B_m == 1), GRBG, G)
 
-    RBg_RBBR = convolve(CFA, Rg_RB_Bg_BR)
-    RBg_BRRB = convolve(CFA, Rg_BR_Bg_RB)
-    RBgr_BBRR = convolve(CFA, Rb_BB_Br_RR)
+    RBg_RBBR = scipy.signal.convolve2d(CFA, Rg_RB_Bg_BR,'same')
+    RBg_RBBR = np.clip(RBg_RBBR,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
+
+    RBg_BRRB = scipy.signal.convolve2d(CFA, Rg_BR_Bg_RB,'same')
+    RBg_BRRB = np.clip(RBg_BRRB,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
+
+    RBgr_BBRR = scipy.signal.convolve2d(CFA, Rb_BB_Br_RR,'same')
+    RBgr_BBRR = np.clip(RBgr_BBRR,0,np.iinfo(CFA.dtype).max).astype(CFA.dtype)
 
     # Red rows.
-    R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) * np.ones(R.shape)
+    R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) * np.ones(R.shape,dtype='bool')
     # Red columns.
-    R_c = np.any(R_m == 1, axis=0)[np.newaxis] * np.ones(R.shape)
+    R_c = np.any(R_m == 1, axis=0)[np.newaxis] * np.ones(R.shape,dtype='bool')
     # Blue rows.
-    B_r = np.transpose(np.any(B_m == 1, axis=1)[np.newaxis]) * np.ones(B.shape)
+    B_r = np.transpose(np.any(B_m == 1, axis=1)[np.newaxis]) * np.ones(B.shape,dtype='bool')
     # Blue columns
-    B_c = np.any(B_m == 1, axis=0)[np.newaxis] * np.ones(B.shape)
+    B_c = np.any(B_m == 1, axis=0)[np.newaxis] * np.ones(B.shape,dtype='bool')
 
     R = np.where(np.logical_and(R_r == 1, B_c == 1), RBg_RBBR, R)
     R = np.where(np.logical_and(B_r == 1, R_c == 1), RBg_BRRB, R)
@@ -145,3 +152,4 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     B = np.where(np.logical_and(R_r == 1, R_c == 1), RBgr_BBRR, B)
 
     return tstack((R, G, B))
+


### PR DESCRIPTION
The existing convolutions caused pixels with a value of zero to underflow. Problem is solved by performing floating point convolutions, and clipping negative pixel values to zero.
nb. scipy.signal dependency is added