### PR TITLE
PR: Switch extension mode in convolve to "mirror".

### DIFF
--- a/colour_demosaicing/bayer/demosaicing/bilinear.py
+++ b/colour_demosaicing/bayer/demosaicing/bilinear.py
@@ -105,8 +105,8 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
          [2, 4, 2],
          [1, 2, 1]]) / 4  # yapf: disable
 
-    R = convolve(CFA * R_m, H_RB)
-    G = convolve(CFA * G_m, H_G)
-    B = convolve(CFA * B_m, H_RB)
+    R = convolve(CFA * R_m, H_RB, mode='mirror')
+    G = convolve(CFA * G_m, H_G, mode='mirror')
+    B = convolve(CFA * B_m, H_RB, mode='mirror')
 
     return tstack((R, G, B))

--- a/colour_demosaicing/bayer/demosaicing/malvar2004.py
+++ b/colour_demosaicing/bayer/demosaicing/malvar2004.py
@@ -127,9 +127,9 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
 
     G = np.where(np.logical_or(R_m == 1, B_m == 1), convolve(CFA, GR_GB), G)
 
-    RBg_RBBR = convolve(CFA, Rg_RB_Bg_BR)
-    RBg_BRRB = convolve(CFA, Rg_BR_Bg_RB)
-    RBgr_BBRR = convolve(CFA, Rb_BB_Br_RR)
+    RBg_RBBR = convolve(CFA, Rg_RB_Bg_BR, mode='mirror')
+    RBg_BRRB = convolve(CFA, Rg_BR_Bg_RB, mode='mirror')
+    RBgr_BBRR = convolve(CFA, Rb_BB_Br_RR, mode='mirror')
 
     # Red rows.
     R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) * np.ones(R.shape)

--- a/colour_demosaicing/bayer/demosaicing/tests/test_bilinear.py
+++ b/colour_demosaicing/bayer/demosaicing/tests/test_bilinear.py
@@ -15,7 +15,7 @@ from colour.io import read_image
 
 from colour_demosaicing import TESTS_RESOURCES_DIRECTORY
 from colour_demosaicing.bayer import demosaicing_CFA_Bayer_bilinear
-from colour.demosaicing.bayer import mosaicing_CFA_Bayer
+from colour_demosaicing.bayer import mosaicing_CFA_Bayer
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2015-2018 - Colour Developers'

--- a/colour_demosaicing/bayer/demosaicing/tests/test_bilinear.py
+++ b/colour_demosaicing/bayer/demosaicing/tests/test_bilinear.py
@@ -15,6 +15,7 @@ from colour.io import read_image
 
 from colour_demosaicing import TESTS_RESOURCES_DIRECTORY
 from colour_demosaicing.bayer import demosaicing_CFA_Bayer_bilinear
+from colour.demosaicing.bayer import mosaicing_CFA_Bayer
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2015-2018 - Colour Developers'
@@ -50,6 +51,21 @@ demosaicing_CFA_Bayer_bilinear` definition.
                     read_image(str(CFA.format(pattern))), pattern),
                 read_image(str(RGB.format(pattern))),
                 decimal=7)
+
+    def test_demosaicing_CFA_Bayer_bilinear_interpolant(self):
+        """
+        Tests whether the result of :func:`colour_demosaicing.bayer.\
+        demosaicing.bilinear.demosaicing_CFA_Bayer_bilinear` agrees
+        with the original values.
+        """
+
+        for pattern in ('RGGB', 'BGGR', 'GRGB', 'GBRG'):
+            CFA_file = os.path.join(BAYER_DIRECTORY, 'Lighthouse_CFA_{0}.exr')
+
+            CFA = read_image(str(CFA_file.format(pattern)))
+            RGB = demosaicing_CFA_Bayer_bilinear(CFA, pattern)
+            CFA_from_RGB = mosaicing_CFA_Bayer(RGB, pattern)
+            np.testing.assert_almost_equal(CFA_from_RGB, CFA, decimal=7)
 
 
 if __name__ == '__main__':

--- a/colour_demosaicing/bayer/demosaicing/tests/test_malvar2004.py
+++ b/colour_demosaicing/bayer/demosaicing/tests/test_malvar2004.py
@@ -15,7 +15,7 @@ from colour.io import read_image
 
 from colour_demosaicing import TESTS_RESOURCES_DIRECTORY
 from colour_demosaicing.bayer import demosaicing_CFA_Bayer_Malvar2004
-from colour.demosaicing.bayer import mosaicing_CFA_Bayer
+from colour_demosaicing.bayer import mosaicing_CFA_Bayer
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2015-2018 - Colour Developers'

--- a/colour_demosaicing/bayer/demosaicing/tests/test_malvar2004.py
+++ b/colour_demosaicing/bayer/demosaicing/tests/test_malvar2004.py
@@ -15,6 +15,7 @@ from colour.io import read_image
 
 from colour_demosaicing import TESTS_RESOURCES_DIRECTORY
 from colour_demosaicing.bayer import demosaicing_CFA_Bayer_Malvar2004
+from colour.demosaicing.bayer import mosaicing_CFA_Bayer
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2015-2018 - Colour Developers'
@@ -51,6 +52,21 @@ demosaicing_CFA_Bayer_Malvar2004` definition.
                     read_image(str(CFA.format(pattern))), pattern),
                 read_image(str(RGB.format(pattern))),
                 decimal=7)
+
+    def test_demosaicing_CFA_Bayer_Malvar2004_interpolant(self):
+        """
+        Tests whether the result of :func:`colour_demosaicing.bayer.\
+        demosaicing.bilinear.demosaicing_CFA_Bayer_Malvar2004` agrees
+        with the original values.
+        """
+
+        for pattern in ('RGGB', 'BGGR', 'GRGB', 'GBRG'):
+            CFA_file = os.path.join(BAYER_DIRECTORY, 'Lighthouse_CFA_{0}.exr')
+
+            CFA = read_image(str(CFA_file.format(pattern)))
+            RGB = demosaicing_CFA_Bayer_Malvar2004(CFA, pattern)
+            CFA_from_RGB = mosaicing_CFA_Bayer(RGB, pattern)
+            np.testing.assert_almost_equal(CFA_from_RGB, CFA, decimal=7)
 
 
 if __name__ == '__main__':

--- a/colour_demosaicing/bayer/demosaicing/tests/test_menon2007.py
+++ b/colour_demosaicing/bayer/demosaicing/tests/test_menon2007.py
@@ -15,7 +15,7 @@ from colour.io import read_image
 
 from colour_demosaicing import TESTS_RESOURCES_DIRECTORY
 from colour_demosaicing.bayer import demosaicing_CFA_Bayer_Menon2007
-from colour.demosaicing.bayer import mosaicing_CFA_Bayer
+from colour_demosaicing.bayer import mosaicing_CFA_Bayer
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2015-2018 - Colour Developers'
@@ -76,7 +76,6 @@ demosaicing_CFA_Bayer_Menon2007` definition.
             RGB = demosaicing_CFA_Bayer_Menon2007(CFA, pattern)
             CFA_from_RGB = mosaicing_CFA_Bayer(RGB, pattern)
             np.testing.assert_almost_equal(CFA_from_RGB, CFA, decimal=7)
-
 
 
 if __name__ == '__main__':

--- a/colour_demosaicing/bayer/demosaicing/tests/test_menon2007.py
+++ b/colour_demosaicing/bayer/demosaicing/tests/test_menon2007.py
@@ -15,6 +15,7 @@ from colour.io import read_image
 
 from colour_demosaicing import TESTS_RESOURCES_DIRECTORY
 from colour_demosaicing.bayer import demosaicing_CFA_Bayer_Menon2007
+from colour.demosaicing.bayer import mosaicing_CFA_Bayer
 
 __author__ = 'Colour Developers'
 __copyright__ = 'Copyright (C) 2015-2018 - Colour Developers'
@@ -60,6 +61,22 @@ demosaicing_CFA_Bayer_Menon2007` definition.
                     refining_step=False),
                 read_image(str(RGB.format(pattern))),
                 decimal=7)
+
+    def test_demosaicing_CFA_Bayer_Menon2007_interpolant(self):
+        """
+        Tests whether the result of :func:`colour_demosaicing.bayer.\
+        demosaicing.bilinear.demosaicing_CFA_Bayer_Menon2007` agrees
+        with the original values.
+        """
+
+        for pattern in ('RGGB', 'BGGR', 'GRGB', 'GBRG'):
+            CFA_file = os.path.join(BAYER_DIRECTORY, 'Lighthouse_CFA_{0}.exr')
+
+            CFA = read_image(str(CFA_file.format(pattern)))
+            RGB = demosaicing_CFA_Bayer_Menon2007(CFA, pattern)
+            CFA_from_RGB = mosaicing_CFA_Bayer(RGB, pattern)
+            np.testing.assert_almost_equal(CFA_from_RGB, CFA, decimal=7)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes issue #8 for the bilinear and Malvar2004 demosaicing. Menon2007 seems to give correct results as it is.