### PR TITLE
Add garbage collection to reduce memory consumption

### DIFF
--- a/colour_demosaicing/bayer/demosaicing/bilinear.py
+++ b/colour_demosaicing/bayer/demosaicing/bilinear.py
@@ -13,7 +13,6 @@ References
 """
 
 from __future__ import division, unicode_literals
-import gc
 
 import numpy as np
 from scipy.ndimage.filters import convolve
@@ -111,6 +110,5 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     B = convolve(CFA * B_m, H_RB)
 
     del R_m, G_m, B_m, H_RB, H_G
-    gc.collect()
 
     return tstack((R, G, B))

--- a/colour_demosaicing/bayer/demosaicing/bilinear.py
+++ b/colour_demosaicing/bayer/demosaicing/bilinear.py
@@ -13,6 +13,7 @@ References
 """
 
 from __future__ import division, unicode_literals
+import gc
 
 import numpy as np
 from scipy.ndimage.filters import convolve
@@ -108,5 +109,8 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     R = convolve(CFA * R_m, H_RB)
     G = convolve(CFA * G_m, H_G)
     B = convolve(CFA * B_m, H_RB)
+
+    del R_m, G_m, B_m, H_RB, H_G
+    gc.collect()
 
     return tstack((R, G, B))

--- a/colour_demosaicing/bayer/demosaicing/malvar2004.py
+++ b/colour_demosaicing/bayer/demosaicing/malvar2004.py
@@ -16,6 +16,7 @@ References
 """
 
 from __future__ import division, unicode_literals
+import gc
 
 import numpy as np
 from scipy.ndimage.filters import convolve
@@ -125,11 +126,17 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     G = CFA * G_m
     B = CFA * B_m
 
+    del G_m
+    gc.collect()
+
     G = np.where(np.logical_or(R_m == 1, B_m == 1), convolve(CFA, GR_GB), G)
 
     RBg_RBBR = convolve(CFA, Rg_RB_Bg_BR)
     RBg_BRRB = convolve(CFA, Rg_BR_Bg_RB)
     RBgr_BBRR = convolve(CFA, Rb_BB_Br_RR)
+
+    del GR_GB, Rg_RB_Bg_BR, Rg_BR_Bg_RB, Rb_BB_Br_RR
+    gc.collect()
 
     # Red rows.
     R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) * np.ones(R.shape)
@@ -140,6 +147,9 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     # Blue columns
     B_c = np.any(B_m == 1, axis=0)[np.newaxis] * np.ones(B.shape)
 
+    del R_m, B_m
+    gc.collect()
+
     R = np.where(np.logical_and(R_r == 1, B_c == 1), RBg_RBBR, R)
     R = np.where(np.logical_and(B_r == 1, R_c == 1), RBg_BRRB, R)
 
@@ -148,5 +158,8 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
 
     R = np.where(np.logical_and(B_r == 1, B_c == 1), RBgr_BBRR, R)
     B = np.where(np.logical_and(R_r == 1, R_c == 1), RBgr_BBRR, B)
+
+    del RBg_RBBR, RBg_BRRB, RBgr_BBRR, R_r, R_c, B_r, B_c
+    gc.collect()
 
     return tstack((R, G, B))

--- a/colour_demosaicing/bayer/demosaicing/malvar2004.py
+++ b/colour_demosaicing/bayer/demosaicing/malvar2004.py
@@ -16,7 +16,6 @@ References
 """
 
 from __future__ import division, unicode_literals
-import gc
 
 import numpy as np
 from scipy.ndimage.filters import convolve
@@ -127,7 +126,6 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     B = CFA * B_m
 
     del G_m
-    gc.collect()
 
     G = np.where(np.logical_or(R_m == 1, B_m == 1), convolve(CFA, GR_GB), G)
 
@@ -136,7 +134,6 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     RBgr_BBRR = convolve(CFA, Rb_BB_Br_RR)
 
     del GR_GB, Rg_RB_Bg_BR, Rg_BR_Bg_RB, Rb_BB_Br_RR
-    gc.collect()
 
     # Red rows.
     R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) * np.ones(R.shape)
@@ -148,7 +145,6 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     B_c = np.any(B_m == 1, axis=0)[np.newaxis] * np.ones(B.shape)
 
     del R_m, B_m
-    gc.collect()
 
     R = np.where(np.logical_and(R_r == 1, B_c == 1), RBg_RBBR, R)
     R = np.where(np.logical_and(B_r == 1, R_c == 1), RBg_BRRB, R)
@@ -160,6 +156,5 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     B = np.where(np.logical_and(R_r == 1, R_c == 1), RBgr_BBRR, B)
 
     del RBg_RBBR, RBg_BRRB, RBgr_BBRR, R_r, R_c, B_r, B_c
-    gc.collect()
 
     return tstack((R, G, B))

--- a/colour_demosaicing/bayer/demosaicing/menon2007.py
+++ b/colour_demosaicing/bayer/demosaicing/menon2007.py
@@ -14,7 +14,6 @@ References
 """
 
 from __future__ import division, unicode_literals
-import gc
 
 import numpy as np
 from scipy.ndimage.filters import convolve, convolve1d
@@ -152,14 +151,12 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     d_V = convolve(D_V, np.transpose(k), mode='constant')
 
     del D_H, D_V
-    gc.collect()
 
     mask = d_V >= d_H
     G = np.where(mask, G_H, G_V)
     M = np.where(mask, 1, 0)
 
     del d_H, d_V, G_H, G_V
-    gc.collect()
 
     # Red rows.
     R_r = np.transpose(np.any(R_m == 1, axis=1)[np.newaxis]) * np.ones(R.shape)
@@ -197,13 +194,11 @@ examples_merge_from_raw_files_with_post_demosaicing.ipynb>`_.
     RGB = tstack((R, G, B))
 
     del R, G, B, k_b, R_r, B_r
-    gc.collect()
 
     if refining_step:
         RGB = refining_step_Menon2007(RGB, tstack((R_m, G_m, B_m)), M)
 
     del M, R_m, G_m, B_m
-    gc.collect()
 
     return RGB
 
@@ -269,7 +264,6 @@ def refining_step_Menon2007(RGB, RGB_m, M):
     M = np.asarray(M)
 
     del RGB, RGB_m
-    gc.collect()
 
     # Updating of the green component.
     R_G = R - G
@@ -283,7 +277,6 @@ def refining_step_Menon2007(RGB, RGB_m, M):
                      np.where(M == 1, _cnv_h(R_G, FIR), _cnv_v(R_G, FIR)), 0)
 
     del B_G, R_G
-    gc.collect()
 
     G = np.where(R_m == 1, R - R_G_m, G)
     G = np.where(B_m == 1, B - B_G_m, G)
@@ -311,7 +304,6 @@ def refining_step_Menon2007(RGB, RGB_m, M):
     R = np.where(np.logical_and(G_m == 1, B_c == 1), G + R_G_m, R)
 
     del B_r, R_G_m, B_c, R_G
-    gc.collect()
 
     B_G_m = np.where(
         np.logical_and(G_m == 1, R_r == 1), _cnv_v(B_G, k_b), B_G_m)
@@ -321,7 +313,6 @@ def refining_step_Menon2007(RGB, RGB_m, M):
     B = np.where(np.logical_and(G_m == 1, R_c == 1), G + B_G_m, B)
 
     del B_G_m, R_r, R_c, G_m, B_G
-    gc.collect()
 
     # Updating of the red (blue) component in the blue (red) locations.
     R_B = R - B
@@ -334,6 +325,5 @@ def refining_step_Menon2007(RGB, RGB_m, M):
     B = np.where(R_m == 1, R - R_B_m, B)
 
     del R_B, R_B_m, R_m
-    gc.collect()
 
     return tstack((R, G, B))


### PR DESCRIPTION
# Summary
Added explicit deletion of temporary variables to reduce the memory consumption of the demosaicing methods.

# Description
In particular for the demosaicing method by Menon, I have noticed a huge memory consumption. In one particular case I was not able to demosaic a large image (around 7000 x 5000) with 14 GB of available memory. By introducing the explicit deletion, I was able to tone it down to 5 GB in that particular case. I've added the garbage collection to the other demosaicing methods as well, even though the gain in memory usage is not as big.