### PR TITLE
PR: Save memory by initialising Bayer CFA masks as  "numpy.bool" directly.

### DIFF
--- a/colour_demosaicing/bayer/masks.py
+++ b/colour_demosaicing/bayer/masks.py
@@ -73,8 +73,8 @@ def masks_CFA_Bayer(
         '"{0}" CFA pattern is invalid, it must be one of {1}!',
     ).upper()
 
-    channels = {channel: zeros(shape) for channel in "RGB"}
+    channels = {channel: zeros(shape, dtype='bool') for channel in "RGB"}
     for channel, (y, x) in zip(pattern, [(0, 0), (0, 1), (1, 0), (1, 1)]):
         channels[channel][y::2, x::2] = 1
 
-    return tuple(channels[c].astype(bool) for c in "RGB")
+    return tuple(channels)

--- a/colour_demosaicing/bayer/masks.py
+++ b/colour_demosaicing/bayer/masks.py
@@ -77,4 +77,4 @@ def masks_CFA_Bayer(
     for channel, (y, x) in zip(pattern, [(0, 0), (0, 1), (1, 0), (1, 1)]):
         channels[channel][y::2, x::2] = 1
 
-    return tuple(channels)
+    return tuple(channels.values())

--- a/colour_demosaicing/bayer/masks.py
+++ b/colour_demosaicing/bayer/masks.py
@@ -73,7 +73,7 @@ def masks_CFA_Bayer(
         '"{0}" CFA pattern is invalid, it must be one of {1}!',
     ).upper()
 
-    channels = {channel: zeros(shape, dtype='bool') for channel in "RGB"}
+    channels = {channel: zeros(shape, dtype="bool") for channel in "RGB"}
     for channel, (y, x) in zip(pattern, [(0, 0), (0, 1), (1, 0), (1, 1)]):
         channels[channel][y::2, x::2] = 1
 


### PR DESCRIPTION
Attempt to accommodate discussions from #42 with return data type as intended.